### PR TITLE
Fix exception with '\r\n' line separator

### DIFF
--- a/src/main/kotlin/com/soywiz/korge/intellij/editor/tile/TiledMapWriter.kt
+++ b/src/main/kotlin/com/soywiz/korge/intellij/editor/tile/TiledMapWriter.kt
@@ -38,13 +38,13 @@ fun TiledMap.toXML(): Xml {
 					node("layer", "id" to layer.id, "name" to layer.name, "width" to layer.width, "height" to layer.height) {
 						node("data", "encoding" to "csv") {
 							text(buildString(layer.area * 4) {
-								appendln()
+                                append("\n")
 								for (y in 0 until layer.height) {
 									for (x in 0 until layer.width) {
 										append(layer.data[x, y].value)
 										if (y != layer.height - 1 || x != layer.width - 1) append(',')
 									}
-									appendln()
+                                    append("\n")
 								}
 							})
 						}


### PR DESCRIPTION
There is an exception `Wrong line separators: '...\"csv\">\n\t\t\t\r\n0,0,0,0,...' at offset...` when calling `appendln()` on Windows. The reason is symbol `\r` which is considered an invalid line separator for files in Intellij IDEA plugins, and `appendln()` adds `\r\n` line separator on Windows by default.